### PR TITLE
Fix for missing projectPath for TDS project types

### DIFF
--- a/code/Sitecore.TestRunnerJS/Init.ps1
+++ b/code/Sitecore.TestRunnerJS/Init.ps1
@@ -4,26 +4,27 @@ $projects = Get-Project -All
 
 foreach ($project in $projects)
 {
-  $projectName = $project.Name
   $projectPath = Split-Path $project.FileName
-  $path = Join-Path ($projectPath) packages.config
-
-  if (Test-Path $path)
+  if ($projectPath)
   {
-    $xml = [xml]$packages = Get-Content $path
-    foreach ($package in $packages.packages.package)
+    $path = Join-Path ($projectPath) packages.config
+    if (Test-Path $path)
     {
-      $id = $package.id
-      if ($id -eq "Sitecore.TestRunnerJS")
+      $xml = [xml]$packages = Get-Content $path
+      foreach ($package in $packages.packages.package)
       {
-				if (Test-Path "$projectPath\App_Config") {
-					Write-Host "TestRunnerJS files location: $toolsPath"
-					Write-Host "Installation location: $projectPath"
+        $id = $package.id
+        if ($id -eq "Sitecore.TestRunnerJS")
+        {
+          if (Test-Path "$projectPath\App_Config") {
+            Write-Host "TestRunnerJS files location: $toolsPath"
+            Write-Host "Installation location: $projectPath"
 
-					Copy-Item -Path "$toolsPath\*" -Destination "$projectPath" -Exclude "*.ps1" -recurse -Force
-					break
-				}
-			}
+            Copy-Item -Path "$toolsPath\*" -Destination "$projectPath" -Exclude "*.ps1" -recurse -Force
+            break
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
TDS projects are missing FileName property hence Join-Path throws an exception 
"Join-Path : Cannot bind argument to parameter 'Path' because it is an empty"
